### PR TITLE
Goose

### DIFF
--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -18,7 +18,7 @@ function showVendor(id,cb){
         }],
         where:  obj
     }).then((result)=>{
-        cb({"result": result})
+        cb({result})
     },(error)=>{
         cb({"result":error})
     })

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -30,11 +30,13 @@ module.exports =  function(app){
             res.json(result)
         })
     });
+
     app.get("/api/viewfarmer/:id?", (req, res) => {
         showVendor(req.params.id,(result)=>{
             res.json(result)
         })
     });
+
     app.get("/api/market/:id?", (req, res) => {
         showVendor(req.params.id,(result)=>{
             res.json(result)


### PR DESCRIPTION
Changing it back to  cb({result}) instead of  cb({"result":result}).  ES6 Object literal value shorthand